### PR TITLE
Allow children to have children

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1273,6 +1273,11 @@
         "is-obj": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
       }
     },
+    "deepmerge": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.0.tgz",
+      "integrity": "sha512-Hm4+NyDQGgH3oYhKqR0gd99veBBZpnEUNoEfFl+3PRkQL+LKGJEBgqimeofAWzUn6aBzcaYPJrRigto/WfDzTg=="
+    },
     "define-properties": {
       "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",

--- a/assets/package.json
+++ b/assets/package.json
@@ -10,6 +10,7 @@
     "babel-preset-react": "^6.24.1",
     "base-64": "^0.1.0",
     "create-styled-element": "^0.5.1",
+    "deepmerge": "^1.5.0",
     "golly": "^0.3.1",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",


### PR DESCRIPTION
When computing children, instead of putting all links of the current
into the current's parent, actually compute which parent the child
should be under and put them there. This allows grandchildren and also
allows the children of one particular parent to reveal children of a
different parent.

<img width="240" alt="screenshot 2017-08-14 15 46 42" src="https://user-images.githubusercontent.com/385726/29295701-aec02b82-810a-11e7-9388-174da72c7e5d.png">